### PR TITLE
Limit export to claims with categories

### DIFF
--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -9,7 +9,8 @@ module Admin
     # end
 
     def export
-      exporter = CsvBinaryMlExporter.new({ claims: Claim.all, categories: Category.all })
+      # Only export claims with at least one category.
+      exporter = CsvBinaryMlExporter.new({ claims: Claim.joins(:categories), categories: Category.all })
       csv = exporter.process
 
       send_data csv


### PR DESCRIPTION
We now only export claims which have at least 1 category.