### PR TITLE
Add instructions page and show on first login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+
+  protected
+  
+  def after_sign_in_path_for(resource)
+    current_user.is_first_login? ? instructions_path : (stored_location_for(resource) || root_path)
+  end
+
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,3 +1,5 @@
 class HomeController < ApplicationController
+  before_action :authenticate_user!, only: [:instructions]
   def index; end
+  def instructions; end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,10 +4,14 @@ class User < ApplicationRecord
   has_many :category_suggestions
 
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :recoverable, :rememberable, :validatable
+  # :confirmable, :lockable, :timeoutable, and :omniauthable
+  devise :database_authenticatable, :recoverable, :rememberable, :trackable, :validatable
 
   after_create :assign_default_role
+
+  def is_first_login?
+    sign_in_count === 1
+  end
 
 private
 

--- a/app/views/home/instructions.html.erb
+++ b/app/views/home/instructions.html.erb
@@ -1,0 +1,17 @@
+<div style="padding-top:50px;padding-bottom:100px">
+  <h4>What am I doing here?</h4>
+  <p>Simply put, you are teaching machines to “think” the way we want them to.</p>
+  <p>Caucus is a simple system for categorizing factual claims made by politicians and other public figures. We’re doing this to help machines learn how to match what a politician says today to similar things they or others have said in the past.</p>
+  <h4>How do I help?</h4>
+  <p>When you get started in Caucus, you will see a claim, as well as the person who said it, the date and the location. You then assign relevant categories to that claim by tapping the button with the category’s name. So for the claim “I opposed the Iraq War,” you would assign categories like “War,” “Iraq,” “Iraq War,” etc. Use the “Filter” field to quickly find the category you’re thinking of. If you can’t find a category that seems relevant, you can use the “Category Suggestion” field to suggest it. The suggestion will then show up in blue, and after submission, an admin will review it.</p>
+  <h4>Tips for helping a machine think:</h4>
+  <ol>
+    <li>More is better. Assign as many categories per claim as are relevant and suggest additional categories if you can.</li>
+    <li>Make sure to think in terms of big, general categories — like “War” — as well as specific ones — like “Syria.” If you can get more specific, that’s great — like “Aleppo.”</li>
+    <li>If a claim is about a person, tag that person as a category. But don’t tag the speaker of a claim unless what they’re saying is about them personally. For example, Donald Trump’s tweet, “I was the person who saved Pre-Existing Conditions in your healthcare” should be tagged with “Donald Trump,” as well as “Health Care” and other relevant categories. But Trump saying, “Earnings for the bottom 10% are rising faster than earnings for the top 10%” would not have “Donald Trump” tagged as a category.</li>
+    <li>Don’t hesitate to suggest categories! We’re beginning with a relatively small list and we expect to need many more in the system. Even if you think a category might not apply to multiple claims, if it’s relevant, suggest it. We can always ignore categories later, but going back through claims to reassign categories is much more difficult.</li>
+    <li>If you’re suggesting people as categories, make sure to use their full names: “William Shakespeare” vs “Shakespeare.”</li>
+    <li>Don’t be afraid to suggest the same category for multiple claims. It can take us a bit of time to approve suggestions, but we can make sure it’s applied to all claims you tag.</li>
+  </ol>
+  <%= link_to "Get Started", winnow_index_path, class: "btn btn-info btn-lg", data: { turbolinks: "false" } %>
+</div>

--- a/app/views/shared/_navigation_bar.html.erb
+++ b/app/views/shared/_navigation_bar.html.erb
@@ -7,7 +7,12 @@
     </div>
     <% end %>
     <div class="navbar-nav">
-      <%= user_signed_in? ? link_to("Logout", destroy_user_session_path, method: :delete, class: "nav-link") : link_to("Login", new_user_session_path, class: "nav-link") %>
+      <% if user_signed_in? %>
+        <%= link_to("Instructions", instructions_path, class: "nav-link") %>
+        <%= link_to("Logout", destroy_user_session_path, method: :delete, class: "nav-link") %>
+      <% else %>
+        <%= link_to("Login", new_user_session_path, class: "nav-link") %>
+      <% end %>
     </div>
   </div>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarToggler" aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
 
   root "home#index"
 
+  get "/instructions", to: "home#instructions", as: :instructions
+
   get "/winnow", to: "winnow#index", as: :winnow_index
   patch "/winnow", to: "winnow#submit", as: :winnow_submit
 

--- a/db/migrate/20200304045551_add_trackable_to_users.rb
+++ b/db/migrate/20200304045551_add_trackable_to_users.rb
@@ -4,16 +4,11 @@ class AddTrackableToUsers < ActiveRecord::Migration[6.0]
       t.integer  :sign_in_count, default: 0, null: false
       t.datetime :current_sign_in_at
       t.datetime :last_sign_in_at
-<<<<<<< HEAD
-      t.inet     :current_sign_in_ip
-      t.inet     :last_sign_in_ip
-=======
       # We don't want to track IP address, so we're not even adding these columns. Leaving this
       # for posterity since these are default Devise::Trackable columns whose accessor methods we
       # manually override in the User model and we want the history / note.
       # t.inet     :current_sign_in_ip
       # t.inet     :last_sign_in_ip
->>>>>>> 9b31e63d0617fdeac7b7d5213885a2a8024e2322
     end
   end
 end

--- a/db/migrate/20200304045551_add_trackable_to_users.rb
+++ b/db/migrate/20200304045551_add_trackable_to_users.rb
@@ -1,0 +1,11 @@
+class AddTrackableToUsers < ActiveRecord::Migration[6.0]
+  def change
+    change_table :users do |t|
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.inet     :current_sign_in_ip
+      t.inet     :last_sign_in_ip
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,11 +78,6 @@ ActiveRecord::Schema.define(version: 2020_03_04_045551) do
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-<<<<<<< HEAD
-    t.inet "current_sign_in_ip"
-    t.inet "last_sign_in_ip"
-=======
->>>>>>> 9b31e63d0617fdeac7b7d5213885a2a8024e2322
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_18_220348) do
+ActiveRecord::Schema.define(version: 2020_03_04_045551) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -35,9 +35,9 @@ ActiveRecord::Schema.define(version: 2020_02_18_220348) do
     t.string "name"
     t.bigint "user_id"
     t.bigint "claim_id"
+    t.bigint "category_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "category_id"
     t.integer "status", default: 0
     t.index ["category_id"], name: "index_category_suggestions_on_category_id"
     t.index ["claim_id"], name: "index_category_suggestions_on_claim_id"
@@ -75,6 +75,11 @@ ActiveRecord::Schema.define(version: 2020_02_18_220348) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
This PR first adds an Instructions page (accessible from the navbar for authenticated users), then enables the Devise::Trackable module to show the Instructions page the first time the user logs in.

Note, however, that we do NOT want to track IP address, so we don't add those columns to the `users` table and override the accessor methods on the `User` model with no-ops.

🚨 **You will need to run migrations after pulling these commits.** 🚨

Resolves #34 
Resolves #35 