### PR TITLE
Add Sentry.io integration for bug tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,3 +108,6 @@ gem "image_processing"
 
 # Because turbolinks doesn't support the `render` method correctly
 gem "turbolinks_render"
+
+# Sentry.io tracks errors and bugs
+gem "sentry-raven"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,6 +303,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sentry-raven (2.13.0)
+      faraday (>= 0.7.6, < 1.0)
     sidekiq (6.0.5)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
@@ -391,6 +393,7 @@ DEPENDENCIES
   rolify
   sassc-rails
   selenium-webdriver
+  sentry-raven
   sidekiq
   simplecov
   spring

--- a/app.json
+++ b/app.json
@@ -61,6 +61,10 @@
       "description": "An AWS region",
       "default": "us-east-1",
       "required": true
+    },
+    "SENTRY_DSN": {
+      "description": "Sentry.io DSN, if set Sentry.io reporting is used, if it's not set Sentry.io is ignored.",
+      "required": false
     }
   },
   "formation": {

--- a/app/jobs/sentry_job.rb
+++ b/app/jobs/sentry_job.rb
@@ -1,0 +1,7 @@
+class SentryJob < ApplicationJob
+  queue_as :default
+
+  def perform(event)
+    Raven.send_event(event)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,13 @@ module Caucus
     # Jobs break unless this happens. Zeigeist gets the wrong job path and errors haard.
     config.load_defaults "6.0"
     config.autoloader = :classic
+
+    # Initialization for Sentry.io, if the environment variable SENTRY_DSN exists, otherwise it is ignored
+    # If using Heroku make sure to run `heroku labs:enable runtime-dyno-metadata -a myapp` to enable release
+    # notifications
+    Raven.configure do |config|
+      config.dsn = ENV["SENTRY_DSN"]
+      config.async = lambda { |event| SentryJob.perform_later(event) }
+    end if ENV.key?("SENTRY_DSN")
   end
 end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -26,3 +26,4 @@ production:
   AWS_SECRET_ACCESS_KEY: "XXXXXXXXX"
   AWS_REGION: "us-east-1"
   DATABASE_URL: "postgres://username:password@host:5432/db_name"
+  SENTRY_DSN: "https://XXXXXXXXXXXXX:XXXXXXXXXXXXX@sentry.io/123456"

--- a/test/jobs/sentry_job_test.rb
+++ b/test/jobs/sentry_job_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SentryJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Sentry.io is a bug managment and tracking system, this adds support for
it.

Specifically it adds the following:
- An optional environment variable `SENTRY_DSN` which, if set, enables
  Sentry.io integration, if not it's ignored
- A job to offload uploading of errors to the Sentry backend so it's
  async.