### PR TITLE
Handle a lack of winnowable claims more gracefully

### DIFF
--- a/app/controllers/winnow_controller.rb
+++ b/app/controllers/winnow_controller.rb
@@ -3,7 +3,7 @@ class WinnowController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @claim = new_claim
+    @claim = winnowable_claim
     # We only want categories not already assigned to the claim
     @categories = Category.all.order("name ASC") - @claim.categories
     turbolinks_animate "slideInRight"
@@ -42,9 +42,9 @@ private
     id_string.split(seperator)
   end
 
-  # Get a new claim to show to a user
-  # This could get interesting with locks and such so it's a seperate function
-  def new_claim
+  # Choose and return a claim that we want the user to winnow. (This could get interesting with
+  # locks and such so it's a separate method.)
+  def winnowable_claim
     claim = Claim.where(checked: false).order("RANDOM()").first
     claim
   end

--- a/app/controllers/winnow_controller.rb
+++ b/app/controllers/winnow_controller.rb
@@ -1,9 +1,9 @@
 class WinnowController < ApplicationController
-  before_action :verify_claim, except: [:index]
   before_action :authenticate_user!
+  before_action :verify_winnowable_claim, only: [:index]
+  before_action :verify_claim, except: [:index]
 
   def index
-    @claim = winnowable_claim
     # We only want categories not already assigned to the claim
     @categories = Category.all.order("name ASC") - @claim.categories
     turbolinks_animate "slideInRight"
@@ -31,6 +31,13 @@ private
     @claim = Claim.find(claim_params[:id])
   rescue ActiveRecord::RecordNotFound
     render file: "#{Rails.root}/public/404.html", layout: false, status: :not_found
+  end
+
+  def verify_winnowable_claim
+    @claim = winnowable_claim
+    if @claim.nil?
+      redirect_to root_path, flash: { notice: "Looks like there are no claims to winnow. Go do something else fun!" }
+    end
   end
 
   def claim_params

--- a/app/views/shared/_messages.html.erb
+++ b/app/views/shared/_messages.html.erb
@@ -26,8 +26,8 @@
 <% end %>
 
 <% if flash[:notice] %>
-  <div class="alert alert-dismissible alert-success" role="alert">
-    <strong>Success:</strong> <%= flash[:notice].html_safe %>
+  <div class="alert alert-dismissible alert-info" role="alert">
+    <%= flash[:notice].html_safe %>
     <button type="button" class="close" data-dismiss="alert" aria-label="Close">
       <span aria-hidden="true">&times;</span>
     </button>


### PR DESCRIPTION
This PR adds protection to the Winnowing process so that if there are no claims available to winnow — such as on new installations or when the user has already winnowed all available claims — we give them a happy message instead of crashing.

It also improves the naming of a core method and improves the styling of notices (which previously were indistinguishable from success messages).

#### Testing

Since our current "select a winnowable claim" logic is just "randomly select a claim with `checked: false`", you could just turn them all `true` so that no claim will be returned, then fire up the app and go to `/winnow`. You should be redirected to the home with a notice about there being no claims to winnow..

Resolves #41