### PR TITLE
Manage memory for export

### DIFF
--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -12,12 +12,18 @@ module Admin
 
     def export
       # Only export claims with at least one category.
-      exporter = CsvBinaryMlExporter.new({ claims: Claim.joins(:categories), categories: Category.all })
-      csv = exporter.process
+      exporter = CsvBinaryMlExporter.new({ claims: Claim.joins(:categories).where.not(categories: []).distinct, categories: Category.all })
+      processed = exporter.process(response, headers)
 
       # send_data csv
       respond_to do |format|
-        format.csv csv
+        format.csv do
+          # rubocop:disable Lint/UselessAssignment
+          headers = processed[:headers]
+          response = processed[:response]
+          self.response_body = processed[:enumerator]
+          # rubocop:enable Lint/UselessAssignment
+        end
       end
     end
 

--- a/app/controllers/admin/claims_controller.rb
+++ b/app/controllers/admin/claims_controller.rb
@@ -15,7 +15,10 @@ module Admin
       exporter = CsvBinaryMlExporter.new({ claims: Claim.joins(:categories), categories: Category.all })
       csv = exporter.process
 
-      send_data csv
+      # send_data csv
+      respond_to do |format|
+        format.csv csv
+      end
     end
 
     # Override this method to specify custom lookup behavior.

--- a/app/exporters/csv_binary_ml_exporter.rb
+++ b/app/exporters/csv_binary_ml_exporter.rb
@@ -24,7 +24,7 @@ class CsvBinaryMlExporter < Exporter
 
       # Go through each claim, create an array big enough with 0, pull the categories, lookup the index, and insert 1
       categories_count = @categories.count
-      @objects.each do |object|
+      @objects.find_each do |object|
         binary_array = create_binary_array(object, categories_count, category_look_up)
         csv << [object.statement, object.id].concat(binary_array)
       end unless @objects.nil?

--- a/app/exporters/exporter.rb
+++ b/app/exporters/exporter.rb
@@ -2,6 +2,7 @@ class Exporter
   def initialize(**args)
     @headers = args[:headers]
     @objects = args[:objects]
+    @http_headers = args[:http_headers]
     # headers can be an array of keys, or a hash in the formate {key: title} (if you want the exported title to be named differently than the key is)
     @headers = Hash[@headers.collect { |item| [item.to_sym, item] } ] if @headers.class == Array
   end

--- a/app/views/admin/claims/index.html.erb
+++ b/app/views/admin/claims/index.html.erb
@@ -54,7 +54,7 @@ It renders the `_table` partial to display details about the resources.
   <div>
     <%= link_to(
       t("export"),
-      [namespace, :claim, :export],
+      [namespace, :claim, :export, format: :csv],
       style: "margin-left: 5px;",
       class: "button",
     ) %>


### PR DESCRIPTION
Exporting a large database can quickly eat up memory. This PR is for playing around to make that work.